### PR TITLE
Changing property prefix to spark2cassandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Refer to for more: [SparkCassWriteConf.scala](https://github.com/jparkie/Spark2C
 
 | Property Name                                       | Default                                     | Description |
 | --------------------------------------------------- |:-------------------------------------------:| ------------|
-| `spark.cassandra.bulk.write.partitioner`            | org.apache.cassandra.dht.Murmur3Partitioner | The 'partitioner' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.write.throughput_mb_per_sec`  | Int.MaxValue                                | The maximum throughput to throttle. |
-| `spark.cassandra.bulk.write.connection_per_host`    | 1                                           | The number of connections per host to utilize when streaming SSTables. |
+| `spark.cassandra_bulk.write.partitioner`            | org.apache.cassandra.dht.Murmur3Partitioner | The 'partitioner' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.write.throughput_mb_per_sec`  | Int.MaxValue                                | The maximum throughput to throttle. |
+| `spark.cassandra_bulk.write.connection_per_host`    | 1                                           | The number of connections per host to utilize when streaming SSTables. |
 
 ### SparkCassServerConf
 
@@ -102,18 +102,18 @@ Refer to for more: [SparkCassServerConf.scala](https://github.com/jparkie/Spark2
 
 | Property Name                                      | Default                                                   | Description |
 | -------------------------------------------------- |:---------------------------------------------------------:| ------------|
-| `spark.cassandra.bulk.server.storage.port`         | 7000                                                      | The 'storage_port' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.sslStorage.port`      | 7001                                                      | The 'ssl_storage_port' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.internode.encryption` | "none"                                                    | The 'server_encryption_options:internode_encryption' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.keyStore.path`        | conf/.keystore                                            | The 'server_encryption_options:keystore' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.keyStore.password`    | cassandra                                                 | The 'server_encryption_options:keystore_password' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.trustStore.path`      | conf/.truststore                                          | The 'server_encryption_options:truststore' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.trustStore.password`  | cassandra                                                 | The 'server_encryption_options:truststore_password' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.protocol`             | TLS                                                       | The 'server_encryption_options:protocol' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.algorithm`            | SunX509                                                   | The 'server_encryption_options:algorithm' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.store.type`           | JKS                                                       | The 'server_encryption_options:store_type' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.cipherSuites`         | TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA | The 'server_encryption_options:cipher_suites' defined in cassandra.yaml. |
-| `spark.cassandra.bulk.server.requireClientAuth`    | false                                                     | The 'server_encryption_options:require_client_auth' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.storage.port`         | 7000                                                      | The 'storage_port' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.sslStorage.port`      | 7001                                                      | The 'ssl_storage_port' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.internode.encryption` | "none"                                                    | The 'server_encryption_options:internode_encryption' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.keyStore.path`        | conf/.keystore                                            | The 'server_encryption_options:keystore' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.keyStore.password`    | cassandra                                                 | The 'server_encryption_options:keystore_password' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.trustStore.path`      | conf/.truststore                                          | The 'server_encryption_options:truststore' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.trustStore.password`  | cassandra                                                 | The 'server_encryption_options:truststore_password' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.protocol`             | TLS                                                       | The 'server_encryption_options:protocol' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.algorithm`            | SunX509                                                   | The 'server_encryption_options:algorithm' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.store.type`           | JKS                                                       | The 'server_encryption_options:store_type' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.cipherSuites`         | TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA | The 'server_encryption_options:cipher_suites' defined in cassandra.yaml. |
+| `spark.cassandra_bulk.server.requireClientAuth`    | false                                                     | The 'server_encryption_options:require_client_auth' defined in cassandra.yaml. |
 
 ## Documentation
 

--- a/src/main/scala/com/github/jparkie/spark/cassandra/conf/SparkCassServerConf.scala
+++ b/src/main/scala/com/github/jparkie/spark/cassandra/conf/SparkCassServerConf.scala
@@ -75,62 +75,62 @@ object SparkCassServerConf {
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_STORAGE_PORT = SparkCassConfParam[Int](
-    name = "spark.cassandra.bulk.server.storage.port",
+    name = "spark.cassandra_bulk.server.storage.port",
     default = 7000
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_SSL_STORAGE_PORT = SparkCassConfParam[Int](
-    name = "spark.cassandra.bulk.server.sslStorage.port",
+    name = "spark.cassandra_bulk.server.sslStorage.port",
     default = 7001
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_INTERNODE_ENCRYPTION = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.internode.encryption",
+    name = "spark.cassandra_bulk.server.internode.encryption",
     default = "none"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_KEYSTORE_PATH = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.keyStore.path",
+    name = "spark.cassandra_bulk.server.keyStore.path",
     default = "conf/.keystore"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_KEYSTORE_PASSWORD = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.keyStore.password",
+    name = "spark.cassandra_bulk.server.keyStore.password",
     default = "cassandra"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER__TRUSTSTORE_PATH = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.trustStore.path",
+    name = "spark.cassandra_bulk.server.trustStore.path",
     default = "conf/.truststore"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_TRUSTSTORE_PASSWORD = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.trustStore.password",
+    name = "spark.cassandra_bulk.server.trustStore.password",
     default = "cassandra"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_PROTOCOL = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.protocol",
+    name = "spark.cassandra_bulk.server.protocol",
     default = "TLS"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_ALGORITHM = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.algorithm",
+    name = "spark.cassandra_bulk.server.algorithm",
     default = "SunX509"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_STORE_TYPE = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.server.store.type",
+    name = "spark.cassandra_bulk.server.store.type",
     default = "JKS"
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_CIPHER_SUITES = SparkCassConfParam[Set[String]](
-    name = "spark.cassandra.bulk.server.cipherSuites",
+    name = "spark.cassandra_bulk.server.cipherSuites",
     default = Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
   )
 
   val SPARK_CASSANDRA_BULK_SERVER_REQUIRE_CLIENT_AUTH = SparkCassConfParam[Boolean](
-    name = "spark.cassandra.bulk.server.requireClientAuth",
+    name = "spark.cassandra_bulk.server.requireClientAuth",
     default = false
   )
 

--- a/src/main/scala/com/github/jparkie/spark/cassandra/conf/SparkCassWriteConf.scala
+++ b/src/main/scala/com/github/jparkie/spark/cassandra/conf/SparkCassWriteConf.scala
@@ -66,17 +66,17 @@ object SparkCassWriteConf {
   )
 
   val SPARK_CASSANDRA_BULK_WRITE_PARTITIONER = SparkCassConfParam[String](
-    name = "spark.cassandra.bulk.write.partitioner",
+    name = "spark.cassandra_bulk.write.partitioner",
     default = "org.apache.cassandra.dht.Murmur3Partitioner"
   )
 
   val SPARK_CASSANDRA_BULK_WRITE_THROUGHPUT_MB_PER_SEC = SparkCassConfParam[Int](
-    name = "spark.cassandra.bulk.write.throughput_mb_per_sec",
+    name = "spark.cassandra_bulk.write.throughput_mb_per_sec",
     default = Int.MaxValue
   )
 
   val SPARK_CASSANDRA_BULK_WRITE_CONNECTIONS_PER_HOST = SparkCassConfParam[Int](
-    name = "spark.cassandra.bulk.write.connection_per_host",
+    name = "spark.cassandra_bulk.write.connection_per_host",
     default = 1
   )
 

--- a/src/test/scala/com/github/jparkie/spark/cassandra/conf/SparkCassServerConfSpec.scala
+++ b/src/test/scala/com/github/jparkie/spark/cassandra/conf/SparkCassServerConfSpec.scala
@@ -8,18 +8,18 @@ class SparkCassServerConfSpec extends WordSpec with MustMatchers {
   "SparkCassServerConf" must {
     "be extracted from SparkConf successfully" in {
       val inputSparkConf = new SparkConf()
-        .set("spark.cassandra.bulk.server.storage.port", "1")
-        .set("spark.cassandra.bulk.server.sslStorage.port", "2")
-        .set("spark.cassandra.bulk.server.internode.encryption", "all")
-        .set("spark.cassandra.bulk.server.keyStore.path", "test_keystore_path")
-        .set("spark.cassandra.bulk.server.keyStore.password", "test_keystore_password")
-        .set("spark.cassandra.bulk.server.trustStore.path", "test_truststore_path")
-        .set("spark.cassandra.bulk.server.trustStore.password", "test_truststore_password")
-        .set("spark.cassandra.bulk.server.protocol", "test_protocol")
-        .set("spark.cassandra.bulk.server.algorithm", "test_algorithm")
-        .set("spark.cassandra.bulk.server.store.type", "test_store_type")
-        .set("spark.cassandra.bulk.server.cipherSuites", "test_cipher_suites_1,test_cipher_suites_2")
-        .set("spark.cassandra.bulk.server.requireClientAuth", "true")
+        .set("spark.cassandra_bulk.server.storage.port", "1")
+        .set("spark.cassandra_bulk.server.sslStorage.port", "2")
+        .set("spark.cassandra_bulk.server.internode.encryption", "all")
+        .set("spark.cassandra_bulk.server.keyStore.path", "test_keystore_path")
+        .set("spark.cassandra_bulk.server.keyStore.password", "test_keystore_password")
+        .set("spark.cassandra_bulk.server.trustStore.path", "test_truststore_path")
+        .set("spark.cassandra_bulk.server.trustStore.password", "test_truststore_password")
+        .set("spark.cassandra_bulk.server.protocol", "test_protocol")
+        .set("spark.cassandra_bulk.server.algorithm", "test_algorithm")
+        .set("spark.cassandra_bulk.server.store.type", "test_store_type")
+        .set("spark.cassandra_bulk.server.cipherSuites", "test_cipher_suites_1,test_cipher_suites_2")
+        .set("spark.cassandra_bulk.server.requireClientAuth", "true")
 
       val outputSparkCassServerConf = SparkCassServerConf.fromSparkConf(inputSparkConf)
 
@@ -70,7 +70,7 @@ class SparkCassServerConfSpec extends WordSpec with MustMatchers {
 
     "reject invalid internode encryption in SparkConf" in {
       val inputSparkConf = new SparkConf()
-        .set("spark.cassandra.bulk.server.internode.encryption", "N/A")
+        .set("spark.cassandra_bulk.server.internode.encryption", "N/A")
 
       intercept[IllegalArgumentException] {
         SparkCassServerConf.fromSparkConf(inputSparkConf)

--- a/src/test/scala/com/github/jparkie/spark/cassandra/conf/SparkCassWriteConfSpec.scala
+++ b/src/test/scala/com/github/jparkie/spark/cassandra/conf/SparkCassWriteConfSpec.scala
@@ -8,9 +8,9 @@ class SparkCassWriteConfSpec extends WordSpec with MustMatchers {
   "SparkCassWriteConf" must {
     "be extracted from SparkConf successfully" in {
       val inputSparkConf = new SparkConf()
-        .set("spark.cassandra.bulk.write.partitioner", "org.apache.cassandra.dht.ByteOrderedPartitioner")
-        .set("spark.cassandra.bulk.write.throughput_mb_per_sec", "1")
-        .set("spark.cassandra.bulk.write.connection_per_host", "2")
+        .set("spark.cassandra_bulk.write.partitioner", "org.apache.cassandra.dht.ByteOrderedPartitioner")
+        .set("spark.cassandra_bulk.write.throughput_mb_per_sec", "1")
+        .set("spark.cassandra_bulk.write.connection_per_host", "2")
 
       val outputSparkCassWriteConf = SparkCassWriteConf.fromSparkConf(inputSparkConf)
 
@@ -34,7 +34,7 @@ class SparkCassWriteConfSpec extends WordSpec with MustMatchers {
 
     "reject invalid partitioner in SparkConf" in {
       val inputSparkConf = new SparkConf()
-        .set("spark.cassandra.bulk.write.partitioner", "N/A")
+        .set("spark.cassandra_bulk.write.partitioner", "N/A")
 
       intercept[IllegalArgumentException] {
         SparkCassWriteConf.fromSparkConf(inputSparkConf)

--- a/src/test/scala/com/github/jparkie/spark/cassandra/sql/SparkCassDataFrameFunctionsSpec.scala
+++ b/src/test/scala/com/github/jparkie/spark/cassandra/sql/SparkCassDataFrameFunctionsSpec.scala
@@ -2,7 +2,7 @@ package com.github.jparkie.spark.cassandra.sql
 
 import com.holdenkarau.spark.testing.SharedSparkContext
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.{ MustMatchers, WordSpec }
 
 class SparkCassDataFrameFunctionsSpec extends WordSpec with MustMatchers with SharedSparkContext {
   "Package com.github.jparkie.spark.cassandra.sql" must {


### PR DESCRIPTION
Need to change the property prefix because the spark connector is
balking at spark.cassandra.bulk.*** properties